### PR TITLE
Modifying the number of worker processes in gunicorn_config.py

### DIFF
--- a/python-flask/conf/gunicorn_config.py
+++ b/python-flask/conf/gunicorn_config.py
@@ -1,7 +1,7 @@
 import multiprocessing
 
 bind = "0.0.0.0:8080"
-workers = (multiprocessing.cpu_count() * 2) + 1
+workers = 1
 accesslog = "-"
 access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 loglevel = "debug"


### PR DESCRIPTION
The microservice-templates contain a folder called config in which the gunicorn configuration details are specified in gunicorn_config.py
Earlier this file had the number worker processes calculated using :
**workers = (multiprocessing.cpu_count() * 2) + 1**.
This has been changed to the value 1 as specified below :
**workers = 1**